### PR TITLE
Comparison with boolean constant fix

### DIFF
--- a/contracts/Auction/Bid.sol
+++ b/contracts/Auction/Bid.sol
@@ -14,8 +14,8 @@ contract NFTBid is NFTFactoryContract {
 
   function Bid(uint256 _saleId) external payable {
     require(_tokenMeta[_saleId].currentOwner != _msgSender());
-    require(_tokenMeta[_saleId].status == true);
-    require(_tokenMeta[_saleId].bidSale == true);
+    require(_tokenMeta[_saleId].status);
+    require(_tokenMeta[_saleId].bidSale);
     require(block.timestamp <= _tokenMeta[_saleId].bidEndTime);
     require(
       _tokenMeta[_saleId].price + ((5 * _tokenMeta[_saleId].price) / 100) <=
@@ -77,8 +77,8 @@ contract NFTBid is NFTFactoryContract {
   {
     LibBid.BidOrder memory bids = Bids[_saleId][_bidOrderID];
     require(msg.sender == _tokenMeta[_saleId].currentOwner);
-    require(bids.withdrawn == false);
-    require(_tokenMeta[_saleId].status == true);
+    require(!bids.withdrawn);
+    require(_tokenMeta[_saleId].status);
 
     LibShare.Share[] memory royalties = LibRoyalty.retrieveRoyalty(
       _tokenMeta[_saleId].collectionAddress,
@@ -123,7 +123,7 @@ contract NFTBid is NFTFactoryContract {
     // BidOrder[] memory bids = Bids[_tokenId];
     LibBid.BidOrder memory bids = Bids[_saleId][_bidId];
     require(bids.buyerAddress == msg.sender);
-    require(bids.withdrawn == false);
+    require(!bids.withdrawn);
     (bool success, ) = payable(msg.sender).call{
       value: bids.price
     }("");

--- a/contracts/Auction/Bid1155.sol
+++ b/contracts/Auction/Bid1155.sol
@@ -12,8 +12,8 @@ contract NFTBid1155 is NFTFactoryContract1155 {
 
     function Bid(uint256 _saleId, uint256 _amount) external payable {
         require(_tokenMeta[_saleId].currentOwner != msg.sender);
-        require(_tokenMeta[_saleId].status == true);
-        require(_tokenMeta[_saleId].bidSale == true);
+        require(_tokenMeta[_saleId].status);
+        require(_tokenMeta[_saleId].bidSale);
         require(msg.value % _amount == 0);
         require(msg.value / _amount >= _tokenMeta[_saleId].price);
         require(_tokenMeta[_saleId].numberOfTokens >= _amount);
@@ -69,8 +69,8 @@ contract NFTBid1155 is NFTFactoryContract1155 {
     {   
         LibBid1155.BidOrder memory bids = Bids[_saleId][_bidOrderID];
         require(msg.sender == _tokenMeta[_saleId].currentOwner);
-        require(bids.withdrawn == false);
-        require(_tokenMeta[_saleId].status == true);
+        require(!bids.withdrawn);
+        require(_tokenMeta[_saleId].status);
         require(_tokenMeta[_saleId].numberOfTokens >= bids.numberOfTokens);
 
         LibShare.Share[] memory royalties = LibRoyalty.retrieveRoyalty(
@@ -113,7 +113,7 @@ contract NFTBid1155 is NFTFactoryContract1155 {
         require(
             bids.buyerAddress == msg.sender
         );
-        require(bids.withdrawn == false);
+        require(!bids.withdrawn);
         (bool success, ) = payable(msg.sender).call{
             value: bids.price
         }("");

--- a/contracts/NFTFactoryContract.sol
+++ b/contracts/NFTFactoryContract.sol
@@ -103,7 +103,7 @@ contract NFTFactoryContract is
 
   function cancelSale(uint256 _saleId) external nonReentrant {
     require(msg.sender == _tokenMeta[_saleId].currentOwner);
-    require(_tokenMeta[_saleId].status == true);
+    require(_tokenMeta[_saleId].status);
 
     _tokenMeta[_saleId].status = false;
     ERC721(_tokenMeta[_saleId].collectionAddress).safeTransferFrom(

--- a/contracts/NFTFactoryContract1155.sol
+++ b/contracts/NFTFactoryContract1155.sol
@@ -39,9 +39,9 @@ contract NFTFactoryContract1155 is
             meta.tokenId
         );
 
-        require(meta.status == true);
+        require(meta.status);
         require(msg.sender != address(0) && msg.sender != meta.currentOwner);
-        require(meta.bidSale == false);
+        require(!meta.bidSale);
         require(meta.numberOfTokens >= _amount);
         require(msg.value >= (meta.price * _amount));
 
@@ -105,7 +105,7 @@ contract NFTFactoryContract1155 is
     function cancelSale(uint256 _saleId) external nonReentrant{
 
         require(msg.sender == _tokenMeta[_saleId].currentOwner);
-        require(_tokenMeta[_saleId].status == true);
+        require(_tokenMeta[_saleId].status);
 
         _tokenMeta[_saleId].status = false;
         ERC1155(_tokenMeta[_saleId].collectionAddress).safeTransferFrom(


### PR DESCRIPTION
Comparison with Boolean constants is not required.

The variable itself can be directly used instead of comparing with a Boolean constant.