### PR TITLE
locked complier version

### DIFF
--- a/contracts/Auction/Bid.sol
+++ b/contracts/Auction/Bid.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "../NFTFactoryContract.sol";
 import "../Libraries/LibRoyalty.sol";

--- a/contracts/Auction/Bid1155.sol
+++ b/contracts/Auction/Bid1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "../NFTFactoryContract1155.sol";
 

--- a/contracts/Libraries/LibBid.sol
+++ b/contracts/Libraries/LibBid.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibBid {
     struct BidOrder {

--- a/contracts/Libraries/LibBid1155.sol
+++ b/contracts/Libraries/LibBid1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibBid1155 {
     struct BidOrder {

--- a/contracts/Libraries/LibCollection.sol
+++ b/contracts/Libraries/LibCollection.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibCollection {
 

--- a/contracts/Libraries/LibCollection1155.sol
+++ b/contracts/Libraries/LibCollection1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibCollection1155 {
 

--- a/contracts/Libraries/LibERC1155.sol
+++ b/contracts/Libraries/LibERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "../TokenERC1155.sol";
 import "./LibShare.sol";

--- a/contracts/Libraries/LibERC721.sol
+++ b/contracts/Libraries/LibERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "../TokenERC721.sol";
 import "./LibShare.sol";

--- a/contracts/Libraries/LibMeta.sol
+++ b/contracts/Libraries/LibMeta.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibMeta {
 

--- a/contracts/Libraries/LibMeta1155.sol
+++ b/contracts/Libraries/LibMeta1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibMeta1155 {
 

--- a/contracts/Libraries/LibRoyalty.sol
+++ b/contracts/Libraries/LibRoyalty.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./LibShare.sol";
 import "../TokenERC721.sol";

--- a/contracts/Libraries/LibShare.sol
+++ b/contracts/Libraries/LibShare.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 library LibShare {
     // Defines the share of royalties for the address

--- a/contracts/NFTFactoryContract.sol
+++ b/contracts/NFTFactoryContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./NFTStorage.sol";
 import "./Libraries/LibShare.sol";

--- a/contracts/NFTFactoryContract1155.sol
+++ b/contracts/NFTFactoryContract1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./NFTStorage1155.sol";
 import "./Libraries/LibShare.sol";

--- a/contracts/NFTStorage.sol
+++ b/contracts/NFTStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./Libraries/LibMeta.sol";
 import "./Libraries/LibBid.sol";

--- a/contracts/NFTStorage1155.sol
+++ b/contracts/NFTStorage1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./Libraries/LibMeta1155.sol";
 import "./Libraries/LibBid1155.sol";

--- a/contracts/PNDC_ERC1155.sol
+++ b/contracts/PNDC_ERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/PNDC_ERC721.sol
+++ b/contracts/PNDC_ERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/contracts/TokenERC1155.sol
+++ b/contracts/TokenERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";

--- a/contracts/TokenERC721.sol
+++ b/contracts/TokenERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/contracts/TokenFactory.sol
+++ b/contracts/TokenFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./Auction/Bid.sol";
 import "./Libraries/LibERC721.sol";

--- a/contracts/TokenFactory1155.sol
+++ b/contracts/TokenFactory1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.2;
 
 import "./Auction/Bid1155.sol";
 import "./Libraries/LibERC1155.sol";


### PR DESCRIPTION
Floating pragma is used across the codebase. It is advised to lock the solidity compiler version instead.